### PR TITLE
Set TextAnnotation.text as required

### DIFF
--- a/openapi/commons/components/schemas/TextAnnotation.yaml
+++ b/openapi/commons/components/schemas/TextAnnotation.yaml
@@ -22,3 +22,4 @@ properties:
 required:
   - start
   - length
+  - text


### PR DESCRIPTION
Make the property `TextAnnotation.text` required. While instance-level performance evaluation can be computed with `TextAnnotation.start` and `TextAnnotation.length` alone, token-based evaluation requires to have access to the text delimited by the values of these two properties (text to be stored in `TextAnnotation.text`).

So far the logic was that the value of this property could be inferred on the client side using the clinical note + the predicted `TextAnnotation.start` and `TextAnnotation.length`. However this would take extra time for the client to open the clinical note and extract this information for each predicted annotation. For this reason, I decided to request from the NLP tools to return the value of `TextAnnotation.text`.