### PR TITLE
Remove the attribute "required" for properties that have a default value

### DIFF
--- a/openapi/commons/components/schemas/ResponsePageMetadata.yaml
+++ b/openapi/commons/components/schemas/ResponsePageMetadata.yaml
@@ -17,7 +17,5 @@ properties:
     description: Total number of results in the result set
     type: integer
 required:
-  - offset
-  - limit
   - links
   - totalResults

--- a/openapi/phi-deidentifier/components/schemas/DeidentificationStep.yaml
+++ b/openapi/phi-deidentifier/components/schemas/DeidentificationStep.yaml
@@ -7,7 +7,7 @@ properties:
     description: The minimum confidence level for a given annotation to be de-identified
     minimum: 0
     maximum: 100
-    example: 42.4
+    example: 95.5
     default: 0
   maskingCharConfig:
     $ref: MaskingCharConfig.yaml
@@ -26,3 +26,5 @@ properties:
         - "text_physical_address"
         - "text_date"
         - "text_person_name"
+required:
+  - annotationTypes

--- a/openapi/phi-deidentifier/components/schemas/MaskingCharConfig.yaml
+++ b/openapi/phi-deidentifier/components/schemas/MaskingCharConfig.yaml
@@ -9,5 +9,3 @@ properties:
     minLength: 1
     maxLength: 1
     default: "*"
-required:
-  - maskingChar


### PR DESCRIPTION
> Using default with required parameters or properties, for example, with path parameters. This does not make sense – if a value is required, the client must always send it, and the default value is never used.

[Source](https://swagger.io/docs/specification/describing-parameters/)