### PR TITLE
Update npm run commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
     - run: npm install
     - name: Lint openapi specifications
       run: |
-        npm run lint:ibm --entrypoint=openapi/${{ matrix.api }}/openapi.yaml
+        npm run lint --api=${{ matrix.api }}
+        npm run validate --api=${{ matrix.api }}
 
   build-and-publish:
     needs: [lint]

--- a/package.json
+++ b/package.json
@@ -5,11 +5,10 @@
     "ibm-openapi-validator": "0.34.1"
   },
   "scripts": {
-    "start": "openapi preview-docs $npm_config_entrypoint",
-    "build": "openapi bundle -o openapi.yaml $npm_config_entrypoint",
-    "lint": "openapi lint $npm_config_entrypoint",
+    "start": "openapi preview-docs ./openapi/${npm_config_api}/openapi.yaml",
+    "build": "openapi bundle -o openapi.yaml ./openapi/${npm_config_api}/openapi.yaml",
+    "lint": "openapi lint ./openapi/${npm_config_api}/openapi.yaml",
     "lint:all": "openapi lint openapi/*/openapi.yaml",
-    "lint:ibm": "openapi bundle -o openapi.yaml $npm_config_entrypoint && ./node_modules/.bin/lint-openapi openapi.yaml",
-    "validate:schemas": "python tools/validate/validate.py validate --json_filepath test/json-samples/tool.json --schema_filepath json-schema/schemas/tool.json"
+    "validate": "npm run build --api=${npm_config_api} && ./node_modules/.bin/lint-openapi openapi.yaml"
   }
 }


### PR DESCRIPTION
Examples of the new commands:

```
npm run start --api=X
npm run build --api=X
npm run lint --api=X
npm run lint:all
npm run validate --api=X
```

where `X` is the name of one of the API folders in the folder `openapi/` (e.g., `data-node`, `date-annotator`)