### PR TITLE
Add Example to DeidentifyRequest Schema

### DIFF
--- a/openapi/phi-deidentifier/components/schemas/DeidentifyRequest.yaml
+++ b/openapi/phi-deidentifier/components/schemas/DeidentifyRequest.yaml
@@ -28,7 +28,7 @@ example:
       annotationTypes:
         - text_physical_address
   note:
-    identifier: note-123
+    identifier: awesome-note
     text: On 12/26/2020, Ms. Chloe Price met with Dr. Prescott in Seattle.
     noteType: loinc:LP29684-5
-    patientId: patient-123
+    patientId: awesome-patient

--- a/openapi/phi-deidentifier/components/schemas/DeidentifyRequest.yaml
+++ b/openapi/phi-deidentifier/components/schemas/DeidentifyRequest.yaml
@@ -11,3 +11,24 @@ properties:
 required:
   - note
   - deidentificationSteps
+example:
+  deidentificationSteps:
+    - confidenceThreshold: 20.0
+      maskingCharConfig:
+        maskingChar: "-"
+      annotationTypes:
+        - text_date
+    - confidenceThreshold: 30.0
+      maskingCharConfig:
+        maskingChar: "#"
+      annotationTypes:
+        - text_person_name
+    - confidenceThreshold: 20.0
+      annotationTypeMaskConfig: {}
+      annotationTypes:
+        - text_physical_address
+  note:
+    identifier: note-123
+    text: On 12/26/2020, Ms. Chloe Price met with Dr. Prescott in Seattle.
+    noteType: loinc:LP29684-5
+    patientId: patient-123


### PR DESCRIPTION
This should fix issue nlpsandbox/phi-deidentifier#82 when this schema change gets pushed into PHI-deidentifier. I tested that 1) the example request works with our implementation and 2) that it gets automatically generated by the stub server.