### PR TITLE
Update License.yaml

### DIFF
--- a/openapi/commons/components/parameters/License.yaml
+++ b/openapi/commons/components/parameters/License.yaml
@@ -37,4 +37,5 @@ enum:
   - ncsa
   - unlicense
   - zlib
+  - none
 example: apache-2.0


### PR DESCRIPTION
The schema is currently forcing the developer to select a public license from [the list documented by GitHub](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/licensing-a-repository), but the developer may not want to specify 1) one of these licenses or 2) a license at all. The solution to 1) is for the developer to contact us so we add the license to the list. This PR aims to solve 2).