### PR TITLE
Add missing value `ip_address` to contactType

### DIFF
--- a/openapi/commons/components/schemas/TextContactAnnotation.yaml
+++ b/openapi/commons/components/schemas/TextContactAnnotation.yaml
@@ -10,6 +10,7 @@ allOf:
         enum:
           - email
           - fax
+          - ip_address
           - phone
           - url
           - other


### PR DESCRIPTION
This value is defined by i2b2 but not included in the 2014 dataset. See https://docs.google.com/document/d/1R1pQRx-6iURjJmmtLyGXVAMMA0ulD3RygHJc_dQ14hw