### PR TITLE
Rename value `id_num` to `id_number`

### DIFF
--- a/openapi/commons/components/schemas/TextIdAnnotation.yaml
+++ b/openapi/commons/components/schemas/TextIdAnnotation.yaml
@@ -12,7 +12,7 @@ allOf:
           - bio_id
           - device
           - health_plan
-          - id_num
+          - id_number
           - license
           - medical_record
           - ssn


### PR DESCRIPTION
Following a best practice to avoid the use abbreviation (less descriptive)