### PR TITLE
Disable dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,11 @@ updates:
     schedule:
       interval: "monthly"
     target-branch: "main"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
     target-branch: "main"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Dependabot is used to automatically detect and propose dependancy update. However the less frequent is one month, which is too often. Instead, this PR is disabling the updates and we will re-activate them periodically (e.g. every 3 months).